### PR TITLE
Add Support for Custom API Governance Rules

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,9 @@
+extends: spectral:oas
+rules:
+  info-contact: off # Disable contact info requirement
+  operation-tags: error # Ensure every operation has a tag
+  info-license: warn # Warn if license info is missing
+  openapi-tags: error # Require defined tags in OpenAPI
+  parameter-description: warn # Warn if parameter descriptions are missing
+  operation-operationId-unique: error # Enforce unique operation IDs
+  operation-summary: warn # Warn if an operation summary is missing

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,9 +1,60 @@
-extends: spectral:oas
+extends:
+  - spectral:oas
+  - governance-rules/governance-rules.yaml  # Include custom governance rules
+
 rules:
-  info-contact: off # Disable contact info requirement
-  operation-tags: error # Ensure every operation has a tag
-  info-license: warn # Warn if license info is missing
-  openapi-tags: error # Require defined tags in OpenAPI
-  parameter-description: warn # Warn if parameter descriptions are missing
-  operation-operationId-unique: error # Enforce unique operation IDs
-  operation-summary: warn # Warn if an operation summary is missing
+  openapi-version:
+    description: "OpenAPI specification must include a version."
+    severity: error
+    given: "$"
+    then:
+      field: "openapi"
+      function: truthy
+
+  info-description:
+    description: "Info object should have a description."
+    severity: warning
+    given: "$.info"
+    then:
+      field: "description"
+      function: truthy
+
+  api-contact:
+    description: "API specifications should include a contact field."
+    severity: warning
+    given: "$.info"
+    then:
+      field: "contact"
+      function: truthy
+
+  operation-summary:
+    description: "Each API operation should have a summary."
+    severity: warning
+    given: "$.paths[*][*]"
+    then:
+      field: "summary"
+      function: truthy
+
+  operation-description:
+    description: "Each API operation should have a description."
+    severity: warning
+    given: "$.paths[*][*]"
+    then:
+      field: "description"
+      function: truthy
+
+  operation-tags:
+    description: "Each API operation should have at least one tag."
+    severity: warning
+    given: "$.paths[*][*]"
+    then:
+      field: "tags"
+      function: truthy
+
+  response-schema:
+    description: "Responses should have a defined schema."
+    severity: error
+    given: "$.paths[*][*].responses[*]"
+    then:
+      field: "content.application/json.schema"
+      function: truthy

--- a/README.md
+++ b/README.md
@@ -1,32 +1,131 @@
-# API Governance Project
+# **API Governance Project**  
 
-Welcome to the API Governance Project, an open-source initiative dedicated to enhancing the quality, consistency, and compliance of APIs within organizations. This project utilizes the [AML Modeling Framework (AMF)](https://github.com/aml-org/amf) to effectively parse, generate, and validate API specifications, thereby facilitating robust API governance.
+Welcome to the **API Governance Project**, an open-source initiative dedicated to improving the **quality, consistency, and compliance** of APIs within organizations. This project leverages the **AML Modeling Framework (AMF)** to efficiently **parse, generate, and validate** API specifications, ensuring robust API governance and adherence to industry best practices.  
 
-## Features
+## 🚀 **Features**  
 
-- **Comprehensive Metadata Parsing**: Leverage AMF to parse various API specifications, including RAML, OpenAPI, and AsyncAPI, into a unified metadata graph.&#8203;:contentReference[oaicite:0]{index=0}
+✔ **Comprehensive Metadata Parsing**  
+Leverages **AMF** to parse various API specifications, including:  
+- **RAML**  
+- **OpenAPI (OAS) 2.0 / 3.0**  
+- **AsyncAPI 2.0**  
+- **JSON-LD ("AMF model")**  
 
-- **Validation and Compliance**
+✔ **Validation and Compliance**  
+- Ensures that APIs conform to **best practices** and **industry standards**.  
+- Detects inconsistencies and enforces **organization-wide policies**.  
 
-- **Extensible Framework**
+✔ **Extensible Framework**  
+- Supports **custom AML-defined models** to extend functionality.  
+- Plugins can be used to support additional formats and models.  
 
-## Getting Started
+---
 
-### AMF 
-AMF natively supports the following formats:
+## 📖 **Getting Started**  
 
-YAML
-JSON
-the following semantic models:
+1️⃣ Prerequisites  
+Before setting up the project, ensure you have:  
+- **Node.js** (v16 or later)  
+- **npm** or **yarn**  
+- **Git**  
 
-WebApi (or "Web APIs" as in "APIs accessible over the network")
-AsyncApi
-and the following syntactic models:
+2️⃣ Installation  
 
-JSON-LD "AMF model"
-RAML 0.8 / 1.0 (mapped to "WebApi")
-OpenAPI (OAS) 2.0 / 3.0 (mapped to "WebApi")
-AsyncAPI 2.0 (mapped to "AsyncApi")
-The models above and any other models may be extended and supported via custom AML-defined models. Other formats and models that cannot be expressed with AML may also be supported via plugins.
+Clone the repository:  
+```bash
+git clone https://github.com/Naman8kumar/www-project-api-governance.git api-governance
+cd api-governance
 
+Install dependencies:
+npm install  # or yarn install
+
+3️⃣ Running the Project
+To start using the API Governance tools, run:
+npm start
+This will initialize the governance framework and allow you to interact with API validation features.
+
+🤝 Contributing
+We welcome contributions! To get started:
+
+1. Fork the repository
+Go to OWASP API Governance and click Fork.
+
+2. Clone your fork
+git clone https://github.com/your-username/www-project-api-governance.git
+cd www-project-api-governance
+
+3. Create a new branch
+git checkout -b feature-branch
+
+4. Make your changes & commit
+git add .
+git commit -m "Add feature X"
+
+5. Push to GitHub & create a Pull Request
+git push origin feature-branch
+
+Go to GitHub and submit a Pull Request (PR).
+For detailed guidelines, check CONTRIBUTING.md
+
+📜 License
+This project is licensed under the Apache 2.0 License. See LICENSE for details.
+
+🔗 Resources & Documentation
+
+AML Modeling Framework (AMF)
+OWASP Official Site
+
+📜 LICENSE
+Apache License
+Version 2.0, January 2004
+Copyright (c) 2025 OWASP
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at:
+http://www.apache.org/licenses/LICENSE-2.0  
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+📌 CONTRIBUTING.md
+Contributing to API Governance Project
+We welcome contributions to the API Governance Project!
+
+📌 How to Contribute
+
+1️⃣ Fork the Repository
+Click the Fork button on GitHub.
+
+2️⃣ Clone Your Fork
+git clone https://github.com/your-username/www-project-api-governance.git
+cd www-project-api-governance
+
+3️⃣ Create a New Branch
+git checkout -b feature-branch
+
+4️⃣ Make Your Changes & Commit
+git add .
+git commit -m "Added feature XYZ"
+
+5️⃣ Push to GitHub & Submit a PR
+git push origin feature-branch
+
+Open a Pull Request (PR) on GitHub and describe your changes.
+
+✅ Code Style Guidelines
+Follow the existing coding style and directory structure.
+Use meaningful commit messages.
+Keep PRs focused and small.
+
+📩 Need Help?
+For any questions, open an issue or join our community discussions.
+
+
+✅ **Now just copy-paste everything as it is!**  
+✅ **Save `README.md`, `LICENSE`, and `CONTRIBUTING.md`**  
+✅ **Commit & push changes** 🚀  
 

--- a/README.md
+++ b/README.md
@@ -32,50 +32,69 @@ Clone the repository and install dependencies:
 git clone https://github.com/Naman8kumar/www-project-api-governance.git
 cd api-governance
 npm install  # or yarn install
+```
 
-3️⃣ Running the Project
-To start the API Governance framework, use:
+3️⃣ Running the Project  
+To start the API Governance framework, use:  
+```bash
 npm start
+```
 This initializes the governance tools, allowing interaction with API validation features.
 
-📂 Project Structure
+4️⃣ API Linting  
+To ensure API specifications follow best practices, run:  
+```bash
+npm run lint:api
+```
+
+📂 Project Structure  
+```
 api-governance/
 │── assets/           
 │── docs/                  # 📄 Documentation  
 │   ├── validation.md      # API Validation Rules  
+│── .spectral.yaml         # 🔧 Linting Configuration  
+│── api-governance-config.json  # 🔧 Custom Governance Config  
 │── README.md              
 │── CONTRIBUTING.md       
 │── LICENSE.md            
 │── SECURITY.md            
 │── _config.yml            
+```
 
-🤝 Contributing
+🤝 Contributing  
 We welcome contributions! Follow these steps:
 
-1️⃣ Fork the Repository
-Click the Fork button on GitHub.
+1️⃣ Fork the Repository  
+Click the Fork button on GitHub.  
 
-2️⃣ Clone Your Fork
+2️⃣ Clone Your Fork  
+```bash
 git clone https://github.com/your-username/www-project-api-governance.git
 cd www-project-api-governance
+```
 
-3️⃣ Create a New Branch
+3️⃣ Create a New Branch  
+```bash
 git checkout -b feature-branch
+```
 
-4️⃣ Make Your Changes & Commit
+4️⃣ Make Your Changes & Commit  
+```bash
 git add .
 git commit -m "Added feature XYZ"
+```
 
-5️⃣ Push to GitHub & Submit a PR
+5️⃣ Push to GitHub & Submit a PR  
+```bash
 git push origin feature-branch
+```
 
 Then, open a Pull Request (PR) on GitHub and describe your changes.
 
-📜 License
+📜 License  
 This project is licensed under the Apache 2.0 License. See LICENSE.md for details.
 
-🔗 Resources & Documentation
-
-AML Modeling Framework (AMF)
-OWASP Official Site
-
+🔗 Resources & Documentation  
+- AML Modeling Framework (AMF)  
+- OWASP Official Site

--- a/README.md
+++ b/README.md
@@ -1,23 +1,20 @@
 # **API Governance Project**  
 
-Welcome to the **API Governance Project**, an open-source initiative dedicated to improving the **quality, consistency, and compliance** of APIs within organizations. This project leverages the **AML Modeling Framework (AMF)** to efficiently **parse, generate, and validate** API specifications, ensuring robust API governance and adherence to industry best practices.  
+Welcome to the **API Governance Project**, an open-source initiative focused on improving the **quality, consistency, and compliance** of APIs. This project leverages the **AML Modeling Framework (AMF)** to efficiently **parse, generate, and validate** API specifications, ensuring robust API governance and adherence to industry standards.  
 
 ## 🚀 **Features**  
 
-✔ **Comprehensive Metadata Parsing**  
-Leverages **AMF** to parse various API specifications, including:  
-- **RAML**  
-- **OpenAPI (OAS) 2.0 / 3.0**  
-- **AsyncAPI 2.0**  
-- **JSON-LD ("AMF model")**  
+✔ **Comprehensive API Specification Parsing**  
+- Supports **RAML, OpenAPI (OAS) 2.0/3.0, AsyncAPI 2.0, JSON-LD (AMF model)**  
+- Transforms API specifications into a structured metadata graph  
 
 ✔ **Validation and Compliance**  
-- Ensures that APIs conform to **best practices** and **industry standards**.  
-- Detects inconsistencies and enforces **organization-wide policies**.  
+- Ensures APIs adhere to **best practices** and **organization-wide policies**  
+- Identifies inconsistencies and enforces compliance with defined API standards  
 
-✔ **Extensible Framework**  
-- Supports **custom AML-defined models** to extend functionality.  
-- Plugins can be used to support additional formats and models.  
+✔ **Extensible & Scalable**  
+- Supports **custom AML-defined models** for extending API governance  
+- Plugin-based system to add support for additional formats  
 
 ---
 
@@ -30,72 +27,30 @@ Before setting up the project, ensure you have:
 - **Git**  
 
 2️⃣ Installation  
-
-Clone the repository:  
+Clone the repository and install dependencies:  
 ```bash
-git clone https://github.com/Naman8kumar/www-project-api-governance.git api-governance
+git clone https://github.com/Naman8kumar/www-project-api-governance.git
 cd api-governance
-
-Install dependencies:
 npm install  # or yarn install
 
 3️⃣ Running the Project
-To start using the API Governance tools, run:
+To start the API Governance framework, use:
 npm start
-This will initialize the governance framework and allow you to interact with API validation features.
+This initializes the governance tools, allowing interaction with API validation features.
+
+📂 Project Structure
+api-governance/
+│── assets/           
+│── docs/                  # 📄 Documentation  
+│   ├── validation.md      # API Validation Rules  
+│── README.md              
+│── CONTRIBUTING.md       
+│── LICENSE.md            
+│── SECURITY.md            
+│── _config.yml            
 
 🤝 Contributing
-We welcome contributions! To get started:
-
-1. Fork the repository
-Go to OWASP API Governance and click Fork.
-
-2. Clone your fork
-git clone https://github.com/your-username/www-project-api-governance.git
-cd www-project-api-governance
-
-3. Create a new branch
-git checkout -b feature-branch
-
-4. Make your changes & commit
-git add .
-git commit -m "Add feature X"
-
-5. Push to GitHub & create a Pull Request
-git push origin feature-branch
-
-Go to GitHub and submit a Pull Request (PR).
-For detailed guidelines, check CONTRIBUTING.md
-
-📜 License
-This project is licensed under the Apache 2.0 License. See LICENSE for details.
-
-🔗 Resources & Documentation
-
-AML Modeling Framework (AMF)
-OWASP Official Site
-
-📜 LICENSE
-Apache License
-Version 2.0, January 2004
-Copyright (c) 2025 OWASP
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at:
-http://www.apache.org/licenses/LICENSE-2.0  
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-📌 CONTRIBUTING.md
-Contributing to API Governance Project
-We welcome contributions to the API Governance Project!
-
-📌 How to Contribute
+We welcome contributions! Follow these steps:
 
 1️⃣ Fork the Repository
 Click the Fork button on GitHub.
@@ -114,18 +69,13 @@ git commit -m "Added feature XYZ"
 5️⃣ Push to GitHub & Submit a PR
 git push origin feature-branch
 
-Open a Pull Request (PR) on GitHub and describe your changes.
+Then, open a Pull Request (PR) on GitHub and describe your changes.
 
-✅ Code Style Guidelines
-Follow the existing coding style and directory structure.
-Use meaningful commit messages.
-Keep PRs focused and small.
+📜 License
+This project is licensed under the Apache 2.0 License. See LICENSE.md for details.
 
-📩 Need Help?
-For any questions, open an issue or join our community discussions.
+🔗 Resources & Documentation
 
-
-✅ **Now just copy-paste everything as it is!**  
-✅ **Save `README.md`, `LICENSE`, and `CONTRIBUTING.md`**  
-✅ **Commit & push changes** 🚀  
+AML Modeling Framework (AMF)
+OWASP Official Site
 

--- a/api-governance-config.json
+++ b/api-governance-config.json
@@ -1,0 +1,57 @@
+{
+  "project": {
+    "name": "API Governance Project",
+    "description": "Configuration file for API Governance validation and metadata rules.",
+    "version": "1.0.0",
+    "maintainers": [
+      {
+        "name": "Naman Kumar",
+        "github": "https://github.com/Naman8kumar"
+      }
+    ]
+  },
+  "apiStandards": {
+    "supportedFormats": ["RAML", "OpenAPI 2.0", "OpenAPI 3.0", "AsyncAPI 2.0", "JSON-LD"],
+    "requiredFields": ["info.title", "info.version", "paths", "components.schemas"],
+    "namingConventions": {
+      "paths": "kebab-case",
+      "parameters": "camelCase",
+      "schemas": "PascalCase"
+    },
+    "securityRequirements": {
+      "authentication": true,
+      "httpsOnly": true,
+      "oauth2Recommended": true
+    }
+  },
+  "validationRules": {
+    "info-title-required": {
+      "description": "Every API spec must have a title defined in the 'info' object.",
+      "severity": "error"
+    },
+    "info-version-semver": {
+      "description": "API version must follow semantic versioning (semver).",
+      "severity": "warn"
+    },
+    "operation-operationId-unique": {
+      "description": "Each operation should have a unique 'operationId'.",
+      "severity": "error"
+    },
+    "no-empty-paths": {
+      "description": "Paths object must not be empty.",
+      "severity": "error"
+    }
+  },
+  "tools": {
+    "lintingEngine": "Spectral",
+    "lintConfigFile": "./docs/validation.yaml"
+  },
+  "scripts": {
+    "validate": "spectral lint ./apispecs/*.yaml",
+    "docs": "open ./docs/validation.md"
+  },
+  "meta": {
+    "lastUpdated": "2025-04-04",
+    "license": "Apache-2.0"
+  }
+}

--- a/docs/governance-rules.md
+++ b/docs/governance-rules.md
@@ -1,0 +1,8 @@
+# Custom API Governance Rules
+
+## How to Add Custom Rules
+1. Add new rules in `governance-rules/governance-rules.yaml`.
+2. Ensure `.spectral.yaml` includes `governance-rules.yaml` under `extends`.
+3. Run API linting with:
+   ```bash
+   npm run lint:api

--- a/docs/linting-rules.md
+++ b/docs/linting-rules.md
@@ -1,0 +1,9 @@
+# API Linting Rules
+
+## Purpose  
+Ensures API specifications follow best practices by enforcing rules using Spectral.
+
+## How to Run Linter  
+Run the following command to check for errors in your OpenAPI spec:  
+```bash
+npm run lint:api

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,0 +1,27 @@
+# API Validation Rules in AMF
+
+AMF (AML Modeling Framework) enforces strict validation rules to ensure API specifications comply with industry standards. Below are key validation checks for different formats:
+
+## 🚀 RAML Validation Rules
+| Rule | Description | ❌ Invalid Example | ✅ Valid Example |
+|------|------------|----------------------|--------------------|
+| Missing Base URI | The `baseUri` field is required in RAML. | `baseUri: ~` (empty) | `baseUri: "https://api.example.com"` |
+| Invalid Data Type | Properties must have correct types. | `type: integer` (for string) | `type: string` |
+
+## 🚀 OpenAPI Validation Rules
+| Rule | Description | ❌ Invalid Example | ✅ Valid Example |
+|------|------------|----------------------|--------------------|
+| Missing Info Object | The `info` object is required in OpenAPI. | No `info` block | `info: {title: 'API', version: '1.0'}` |
+| Invalid Path Parameter | Path params must be defined in `parameters`. | `{ "get": { "operationId": "getUser" }}` | `{ "parameters": [{ "name": "userId", "in": "path", "required": true }]}` |
+
+## 🚀 AsyncAPI Validation Rules
+| Rule | Description | ❌ Invalid Example | ✅ Valid Example |
+|------|------------|----------------------|--------------------|
+| Missing AsyncAPI Version | `asyncapi` field is mandatory. | `asyncapi: ~` | `asyncapi: "2.0.0"` |
+| Invalid Channel Binding | Bindings must be properly structured. | `{ "bindings": { "http": { "type": "invalid" }}}` | `{ "bindings": { "http": { "type": "request" }}}` |
+
+### 📌 Why This Matters?
+- Ensures **API compliance with industry standards**.
+- Helps developers **quickly debug validation issues**.
+- Improves **overall API governance & documentation clarity**.
+

--- a/governance-rules/governance-rules.yaml
+++ b/governance-rules/governance-rules.yaml
@@ -1,0 +1,24 @@
+rules:
+  openapi-version:
+    description: "OpenAPI specification must include a version."
+    severity: error
+    given: "$"
+    then:
+      field: "openapi"
+      function: truthy
+
+  api-contact:
+    description: "API specifications should include a contact field."
+    severity: warning
+    given: "$.info"
+    then:
+      field: "contact"
+      function: truthy
+
+  operation-summary:
+    description: "Each API operation should have a summary."
+    severity: warning
+    given: "$.paths[*][*]"
+    then:
+      field: "summary"
+      function: truthy


### PR DESCRIPTION
This PR introduces support for defining and extending custom API governance rules, allowing users to enforce organization-specific API standards.

Key Updates:
✅ Created governance-rules/ directory to store user-defined governance rules.
✅ Updated .spectral.yaml to import custom governance rules.
✅ Added docs/governance-rules.md to document how to create and apply governance rules.

This enhancement improves API compliance, flexibility, and maintainability by enabling custom rule definitions. 