### PR TITLE
Add Sample API Specifications for Testing Governance Rules

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,8 +1,10 @@
-extends: ["spectral:oas", "governance-rules/governance-rules.yaml"]
+extends:
+  - "spectral:oas"
+  - "./governance-rules/governance-rules.yaml"
 
 rules:
   info-contact:
-    description: "Info object should contain a contact field."
+    description: "The API info object must include a contact field for better support traceability."
     severity: warning
     given: "$.info"
     then:
@@ -10,7 +12,7 @@ rules:
       function: truthy
 
   operation-summary:
-    description: "Each API operation should have a summary."
+    description: "Each API operation must have a summary to improve documentation."
     severity: warning
     given: "$.paths[*][*]"
     then:
@@ -18,22 +20,31 @@ rules:
       function: truthy
 
   unused-component:
-    description: "Remove unused components from the API spec."
+    description: "Remove unused schemas/components to keep the spec clean."
     severity: info
     given: "$.components.schemas.*"
     then:
       function: unreferenced
 
   missing-tags:
-    description: "Operations should include a 'tags' field for better categorization."
+    description: "Each operation should include a 'tags' field for logical grouping."
     severity: error
     given: "$.paths[*][*]"
     then:
       field: "tags"
       function: truthy
 
+  operation-operationId-naming:
+    description: "Enforce camelCase naming convention for operationId."
+    severity: error
+    given: "$.paths[*][*].operationId"
+    then:
+      function: pattern
+      functionOptions:
+        match: "^[a-z]+([A-Z][a-z0-9]+)*$"
+
 formats:
   - oas2
   - oas3
 
-functionsDir: governance-rules/functions
+functionsDir: "./governance-rules/functions"

--- a/docs/naming-conventions.mdmarkdownCopyEdit
+++ b/docs/naming-conventions.mdmarkdownCopyEdit
@@ -1,0 +1,17 @@
+# Naming Conventions for API Specs
+
+This document outlines the naming conventions enforced across API specifications.
+
+## ✅ Enforced Rules
+
+### 1. Parameter Naming
+- All parameter names must be in kebab-case.
+- Example: `user-id`, `start-date`
+
+### 2. Path Segment Naming
+- API path segments must be in kebab-case or path params.
+- Example: `/user-profile/{user-id}`
+
+### 3. Response Descriptions
+- Descriptions must start with a capital letter.
+- Example: `"Successful operation"` ✅ vs `"successful operation"` ❌

--- a/governance-rules/naming-conventions.yaml
+++ b/governance-rules/naming-conventions.yaml
@@ -1,0 +1,27 @@
+rules:
+  param-name-kebab-case:
+    description: "Parameter names should be in kebab-case."
+    severity: warning
+    given: "$.paths[*][*].parameters[*].name"
+    then:
+      function: pattern
+      functionOptions:
+        match: "^[a-z]+(-[a-z]+)*$"
+
+  path-name-kebab-case:
+    description: "Path segments should be in kebab-case."
+    severity: warning
+    given: "$.paths"
+    then:
+      function: pattern
+      functionOptions:
+        match: "^(/([a-z]+(-[a-z]+)*|{[^}]+}))*$"
+
+  response-description-sentence-case:
+    description: "Response descriptions should start with a capital letter."
+    severity: info
+    given: "$.paths[*][*].responses[*].description"
+    then:
+      function: pattern
+      functionOptions:
+        match: "^[A-Z].*"

--- a/specs/bookstore.yaml
+++ b/specs/bookstore.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.0
+info:
+  title: Book Store API
+  version: 1.0.0
+  contact:
+    email: contact@bookstore.com
+paths:
+  /books:
+    get:
+      summary: Get list of books
+      operationId: getBooks
+      tags:
+        - books
+      responses:
+        '200':
+          description: List of books
+components:
+  schemas:
+    Book:
+      type: object
+      properties:
+        title:
+          type: string
+        author:
+          type: string
+        isbn:
+          type: string

--- a/specs/petstore.yaml
+++ b/specs/petstore.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.0
+info:
+  title: Sample Pet Store API
+  version: 1.0.0
+  contact:
+    email: support@petstore.example.com
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      responses:
+        '200':
+          description: A list of pets.
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string

--- a/specs/sample-api.yaml
+++ b/specs/sample-api.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.0
+info:
+  title: Dummy API Spec
+  description: This is a sample API specification for testing Spectral linting GitHub Action.
+  version: 1.0.0
+paths:
+  /hello:
+    get:
+      summary: Say hello
+      responses:
+        '200':
+          description: A successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string

--- a/specs/weather-api.yaml
+++ b/specs/weather-api.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.0
+info:
+  title: Weather Info API
+  version: 1.0.0
+  contact:
+    name: Weather Support
+    email: help@weatherapi.example.com
+paths:
+  /weather:
+    get:
+      summary: Get current weather
+      operationId: getWeather
+      tags:
+        - weather
+      parameters:
+        - name: city
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Weather details
+components:
+  schemas:
+    WeatherResponse:
+      type: object
+      properties:
+        temperature:
+          type: string
+        condition:
+          type: string


### PR DESCRIPTION
This pull request introduces a set of sample API specifications to support testing of custom governance rules defined in the project.

Key Additions:

specs/petstore.yaml: A minimal Pet Store API based on the Swagger example.

specs/weather-api.yaml: A simple weather information API.

specs/bookstore.yaml: Book store API to help validate naming conventions and required fields.

These sample specs will:

Help validate the effectiveness of Spectral linting rules.

Provide examples for contributors to test and extend governance rules.

Support documentation with real-world testing cases.