### PR TITLE
Implement Rule for Mandatory API Response Descriptions

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -4,7 +4,7 @@ extends:
 
 rules:
   info-contact:
-    description: "The API info object must include a 'contact' field to facilitate support and ownership."
+    description: "The API info object must include a contact field for support traceability."
     severity: warning
     given: "$.info"
     then:
@@ -12,41 +12,41 @@ rules:
       function: truthy
 
   operation-summary:
-    description: "Each API operation must provide a 'summary' to improve documentation and readability."
+    description: "Each API operation must have a summary to improve documentation."
     severity: warning
-    given: "$.paths[*][*]"
+    given: "$.paths[*][get,post,put,delete,patch]"
     then:
       field: "summary"
       function: truthy
 
-  unused-components:
-    description: "Remove unused schemas/components to keep the API spec clean and efficient."
+  unused-component:
+    description: "Remove unused schemas/components to keep the spec clean."
     severity: info
     given: "$.components.schemas.*"
     then:
       function: unreferenced
 
   missing-tags:
-    description: "Each operation must include a 'tags' field for logical categorization and grouping."
+    description: "Each operation should include a 'tags' field for logical grouping."
     severity: error
-    given: "$.paths[*][*]"
+    given: "$.paths[*][get,post,put,delete,patch]"
     then:
       field: "tags"
       function: truthy
 
   operation-operationId-naming:
-    description: "Enforce camelCase naming convention for 'operationId' to maintain consistency."
+    description: "Enforce camelCase naming convention for operationId."
     severity: error
-    given: "$.paths[*][*].operationId"
+    given: "$.paths[*][get,post,put,delete,patch].operationId"
     then:
       function: pattern
       functionOptions:
         match: "^[a-z]+([A-Z][a-z0-9]+)*$"
 
   response-description:
-    description: "Each API response must include a 'description' to improve clarity and documentation quality."
+    description: "Each API response must have a description for clarity."
     severity: error
-    given: "$.paths[*][*].responses[*]"
+    given: "$.paths[*][get,post,put,delete,patch].responses[*]"
     then:
       field: "description"
       function: truthy

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,8 +1,10 @@
-extends: ["spectral:oas", "governance-rules/governance-rules.yaml"]
+extends:
+  - "spectral:oas"
+  - "./governance-rules/governance-rules.yaml"
 
 rules:
   info-contact:
-    description: "Info object should contain a contact field."
+    description: "The API info object must include a contact field for better support traceability."
     severity: warning
     given: "$.info"
     then:
@@ -10,7 +12,7 @@ rules:
       function: truthy
 
   operation-summary:
-    description: "Each API operation should have a summary."
+    description: "Each API operation must have a summary to improve documentation."
     severity: warning
     given: "$.paths[*][*]"
     then:
@@ -18,22 +20,31 @@ rules:
       function: truthy
 
   unused-component:
-    description: "Remove unused components from the API spec."
+    description: "Remove unused schemas/components to keep the spec clean."
     severity: info
     given: "$.components.schemas.*"
     then:
       function: unreferenced
 
   missing-tags:
-    description: "Operations should include a 'tags' field for better categorization."
+    description: "Each operation should include a 'tags' field for logical grouping."
     severity: error
     given: "$.paths[*][*]"
     then:
       field: "tags"
       function: truthy
 
+  operation-operationId-naming:
+    description: "Enforce camelCase naming convention for operationId."
+    severity: error
+    given: "$.paths[*][*].operationId"
+    then:
+      function: pattern
+      functionOptions:
+        match: "^[a-z]+([A-Z][a-z0-9]+)*$"
+
 formats:
   - oas2
   - oas3
 
-functionsDir: governance-rules/functions
+functionsDir: "./governance-rules/functions"

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -4,7 +4,7 @@ extends:
 
 rules:
   info-contact:
-    description: "The API info object must include a contact field for better support traceability."
+    description: "The API info object must include a 'contact' field to facilitate support and ownership."
     severity: warning
     given: "$.info"
     then:
@@ -12,22 +12,22 @@ rules:
       function: truthy
 
   operation-summary:
-    description: "Each API operation must have a summary to improve documentation."
+    description: "Each API operation must provide a 'summary' to improve documentation and readability."
     severity: warning
     given: "$.paths[*][*]"
     then:
       field: "summary"
       function: truthy
 
-  unused-component:
-    description: "Remove unused schemas/components to keep the spec clean."
+  unused-components:
+    description: "Remove unused schemas/components to keep the API spec clean and efficient."
     severity: info
     given: "$.components.schemas.*"
     then:
       function: unreferenced
 
   missing-tags:
-    description: "Each operation should include a 'tags' field for logical grouping."
+    description: "Each operation must include a 'tags' field for logical categorization and grouping."
     severity: error
     given: "$.paths[*][*]"
     then:
@@ -35,13 +35,21 @@ rules:
       function: truthy
 
   operation-operationId-naming:
-    description: "Enforce camelCase naming convention for operationId."
+    description: "Enforce camelCase naming convention for 'operationId' to maintain consistency."
     severity: error
     given: "$.paths[*][*].operationId"
     then:
       function: pattern
       functionOptions:
         match: "^[a-z]+([A-Z][a-z0-9]+)*$"
+
+  response-description:
+    description: "Each API response must include a 'description' to improve clarity and documentation quality."
+    severity: error
+    given: "$.paths[*][*].responses[*]"
+    then:
+      field: "description"
+      function: truthy
 
 formats:
   - oas2

--- a/README.md
+++ b/README.md
@@ -1,100 +1,58 @@
-# **API Governance Project**  
+# 🛡️ OWASP API Governance
 
-Welcome to the **API Governance Project**, an open-source initiative focused on improving the **quality, consistency, and compliance** of APIs. This project leverages the **AML Modeling Framework (AMF)** to efficiently **parse, generate, and validate** API specifications, ensuring robust API governance and adherence to industry standards.  
-
-## 🚀 **Features**  
-
-✔ **Comprehensive API Specification Parsing**  
-- Supports **RAML, OpenAPI (OAS) 2.0/3.0, AsyncAPI 2.0, JSON-LD (AMF model)**  
-- Transforms API specifications into a structured metadata graph  
-
-✔ **Validation and Compliance**  
-- Ensures APIs adhere to **best practices** and **organization-wide policies**  
-- Identifies inconsistencies and enforces compliance with defined API standards  
-
-✔ **Extensible & Scalable**  
-- Supports **custom AML-defined models** for extending API governance  
-- Plugin-based system to add support for additional formats  
+A lightweight project for enforcing API governance using Spectral. It ensures your OpenAPI specifications follow best practices, consistent naming conventions, and organization-wide rules.
 
 ---
 
-## 📖 **Getting Started**  
+## 🚀 Features
 
-1️⃣ Prerequisites  
-Before setting up the project, ensure you have:  
-- **Node.js** (v16 or later)  
-- **npm** or **yarn**  
-- **Git**  
+- ✅ Lint OpenAPI 2.0 & 3.0 specs
+- ✅ Custom governance rules with Spectral
+- ✅ Naming conventions, summaries, tags, and more
+- ✅ Optimized with compiled rulesets
+- ✅ GitHub Actions support for CI linting
 
-2️⃣ Installation  
-Clone the repository and install dependencies:  
+---
+
+## 📁 Project Structure
+
+api-governance/ ├── .spectral.yaml # Main ruleset config ├── compiled-ruleset.json # Compiled version (faster linting) ├── governance-rules/ # Custom rule files │ ├── governance-rules.yaml │ ├── naming-conventions.yaml │ └── functions/ ├── specs/ # Sample OpenAPI specs ├── docs/ # Documentation ├── .github/workflows/ # GitHub CI │ └── lint-api.yml ├── package.json └── README.md
+
+
+---
+
+## 🧪 Linting Commands
+
+Install dependencies:
+
 ```bash
-git clone https://github.com/Naman8kumar/www-project-api-governance.git
-cd api-governance
-npm install  # or yarn install
-```
+npm install
 
-3️⃣ Running the Project  
-To start the API Governance framework, use:  
-```bash
-npm start
-```
-This initializes the governance tools, allowing interaction with API validation features.
+Compile ruleset:
+npm run lint:compile
 
-4️⃣ API Linting  
-To ensure API specifications follow best practices, run:  
-```bash
+Lint all API specs:
 npm run lint:api
-```
 
-📂 Project Structure  
-```
-api-governance/
-│── assets/           
-│── docs/                  # 📄 Documentation  
-│   ├── validation.md      # API Validation Rules  
-│── .spectral.yaml         # 🔧 Linting Configuration  
-│── api-governance-config.json  # 🔧 Custom Governance Config  
-│── README.md              
-│── CONTRIBUTING.md       
-│── LICENSE.md            
-│── SECURITY.md            
-│── _config.yml            
-```
+Lint a single API spec:
+npx spectral lint -r compiled-ruleset.json specs/example-api.yaml
 
-🤝 Contributing  
-We welcome contributions! Follow these steps:
+🤝 Contributing
+Fork this repo
 
-1️⃣ Fork the Repository  
-Click the Fork button on GitHub.  
+Create a new branch
 
-2️⃣ Clone Your Fork  
-```bash
-git clone https://github.com/your-username/www-project-api-governance.git
-cd www-project-api-governance
-```
+Make changes
 
-3️⃣ Create a New Branch  
-```bash
-git checkout -b feature-branch
-```
+Run npm run lint:compile and npm run lint:api
 
-4️⃣ Make Your Changes & Commit  
-```bash
-git add .
-git commit -m "Added feature XYZ"
-```
+Submit a PR 🎉
 
-5️⃣ Push to GitHub & Submit a PR  
-```bash
-git push origin feature-branch
-```
+📜 License
+Apache 2.0 License
 
-Then, open a Pull Request (PR) on GitHub and describe your changes.
+🔗 Resources
 
-📜 License  
-This project is licensed under the Apache 2.0 License. See LICENSE.md for details.
+OWASP API Security
+Spectral Documentation
 
-🔗 Resources & Documentation  
-- AML Modeling Framework (AMF)  
-- OWASP Official Site

--- a/docs/governance-rules.md
+++ b/docs/governance-rules.md
@@ -1,36 +1,58 @@
-# API Governance Rules
+# 🔐 API Governance Rules
 
-This document outlines the rules enforced by Spectral for API validation and governance.
-
-## 🔍 Error Reporting & Severity Levels
-
-Each rule is assigned a severity level:
-
-- 🛑 **Error** → Must be fixed for API compliance.
-- ⚠️ **Warning** → Recommended improvements.
-- ℹ️ **Info** → General guidance.
-
-## 🔎 Examples of Improved Error Messages
-
-1. **Missing Contact Field in API Info**  
-   - **Error Message:** `"API specifications should include a contact field."`
-   - **Severity:** ⚠️ Warning  
-   - **Fix:** Add a `contact` field in `info` object.
-
-2. **Missing Tags in API Operations**  
-   - **Error Message:** `"Operations should include a 'tags' field for better categorization."`
-   - **Severity:** 🛑 Error  
-   - **Fix:** Ensure every API operation has a `tags` field.
-
-3. **Unused Component in API Spec**  
-   - **Error Message:** `"Unused components should be removed."`
-   - **Severity:** ℹ️ Info  
-   - **Fix:** Remove unreferenced schemas from `components`.
+This document outlines the rules enforced by Spectral to ensure consistency, clarity, and maintainability across API specifications.
 
 ---
 
-## 📜 How to Run API Linting  
-Run the following command to validate your API specifications:
+## 🔍 Error Reporting & Severity Levels
+
+Each rule is categorized based on its importance:
+
+| Severity  | Symbol | Meaning                                    |
+|-----------|--------|--------------------------------------------|
+| 🛑 Error   | `error` | Must be fixed for API compliance           |
+| ⚠️ Warning | `warning` | Recommended for better documentation       |
+| ℹ️ Info    | `info` | Optional cleanup or best practices         |
+
+---
+
+## ✅ Enforced Governance Rules
+
+### 1. **Missing Contact Field in API Info**
+- **Message:** `"The API info object must include a contact field."`
+- **Severity:** ⚠️ Warning  
+- **Fix:** Add a `contact` field inside the `info` object.
+
+### 2. **Missing Tags in API Operations**
+- **Message:** `"Each operation must include a 'tags' field for logical categorization."`
+- **Severity:** 🛑 Error  
+- **Fix:** Add a `tags` array for each operation under `paths`.
+
+### 3. **Missing Summary in API Operations**
+- **Message:** `"Each API operation must provide a summary."`
+- **Severity:** ⚠️ Warning  
+- **Fix:** Include a `summary` field for each HTTP method.
+
+### 4. **Unused Components in the API Spec**
+- **Message:** `"Remove unused schemas/components to keep the spec clean."`
+- **Severity:** ℹ️ Info  
+- **Fix:** Remove any unreferenced components from `components.schemas`.
+
+### 5. **Invalid Operation ID Naming**
+- **Message:** `"Enforce camelCase naming convention for operationId."`
+- **Severity:** 🛑 Error  
+- **Fix:** Update all `operationId` values to use camelCase (e.g., `getUserDetails`).
+
+### 6. **Missing Description in Responses**
+- **Message:** `"Each API response must include a description for clarity."`
+- **Severity:** 🛑 Error  
+- **Fix:** Add a `description` field to each response (e.g., `200`, `404`).
+
+---
+
+## 🧪 How to Run API Linting
+
+To validate your OpenAPI/Swagger files using Spectral, run:
 
 ```bash
 npm run lint:api

--- a/docs/naming-conventions.mdmarkdownCopyEdit
+++ b/docs/naming-conventions.mdmarkdownCopyEdit
@@ -1,0 +1,17 @@
+# Naming Conventions for API Specs
+
+This document outlines the naming conventions enforced across API specifications.
+
+## ✅ Enforced Rules
+
+### 1. Parameter Naming
+- All parameter names must be in kebab-case.
+- Example: `user-id`, `start-date`
+
+### 2. Path Segment Naming
+- API path segments must be in kebab-case or path params.
+- Example: `/user-profile/{user-id}`
+
+### 3. Response Descriptions
+- Descriptions must start with a capital letter.
+- Example: `"Successful operation"` ✅ vs `"successful operation"` ❌

--- a/governance-rules/governance-rules.yaml
+++ b/governance-rules/governance-rules.yaml
@@ -1,14 +1,14 @@
 rules:
   openapi-version:
-    description: "OpenAPI specification must include a version."
+    description: "The OpenAPI specification must define an 'openapi' version."
     severity: error
     given: "$"
     then:
       field: "openapi"
       function: truthy
 
-  api-contact:
-    description: "API specifications should include a contact field."
+  info-contact:
+    description: "The API info object must include a 'contact' field to facilitate support and ownership."
     severity: warning
     given: "$.info"
     then:
@@ -16,16 +16,24 @@ rules:
       function: truthy
 
   operation-summary:
-    description: "Each API operation should have a summary."
+    description: "Each API operation should provide a 'summary' to improve readability and documentation."
     severity: warning
     given: "$.paths[*][*]"
     then:
       field: "summary"
       function: truthy
 
-  unused-component:
-    description: "Unused components should be removed."
+  unused-components:
+    description: "Remove unused components to keep the API spec clean and maintainable."
     severity: info
     given: "$.components.schemas.*"
     then:
       function: unreferenced
+
+  response-description:
+    description: "Each API response must include a 'description' for clarity and proper documentation."
+    severity: error
+    given: "$.paths[*][*].responses[*]"
+    then:
+      field: "description"
+      function: truthy

--- a/governance-rules/governance-rules.yaml
+++ b/governance-rules/governance-rules.yaml
@@ -1,14 +1,14 @@
 rules:
   openapi-version:
-    description: "The OpenAPI specification must define an 'openapi' version."
+    description: "OpenAPI specification must include a version."
     severity: error
     given: "$"
     then:
       field: "openapi"
       function: truthy
 
-  info-contact:
-    description: "The API info object must include a 'contact' field to facilitate support and ownership."
+  api-contact:
+    description: "API specifications should include a contact field."
     severity: warning
     given: "$.info"
     then:
@@ -16,24 +16,41 @@ rules:
       function: truthy
 
   operation-summary:
-    description: "Each API operation should provide a 'summary' to improve readability and documentation."
+    description: "Each operation should have a summary."
     severity: warning
-    given: "$.paths[*][*]"
+    given: "$.paths[*][get,post,put,delete,patch]"
     then:
       field: "summary"
       function: truthy
 
-  unused-components:
-    description: "Remove unused components to keep the API spec clean and maintainable."
+  unused-component:
+    description: "Unused components should be removed."
     severity: info
     given: "$.components.schemas.*"
     then:
       function: unreferenced
 
-  response-description:
-    description: "Each API response must include a 'description' for clarity and proper documentation."
+  missing-tags:
+    description: "Each operation should include tags."
     severity: error
-    given: "$.paths[*][*].responses[*]"
+    given: "$.paths[*][get,post,put,delete,patch]"
+    then:
+      field: "tags"
+      function: truthy
+
+  operation-operationId-naming:
+    description: "operationId should follow camelCase."
+    severity: error
+    given: "$.paths[*][get,post,put,delete,patch].operationId"
+    then:
+      function: pattern
+      functionOptions:
+        match: "^[a-z]+([A-Z][a-z0-9]+)*$"
+
+  response-description:
+    description: "Each response must include a description."
+    severity: error
+    given: "$.paths[*][get,post,put,delete,patch].responses[*]"
     then:
       field: "description"
       function: truthy

--- a/governance-rules/naming-conventions.yaml
+++ b/governance-rules/naming-conventions.yaml
@@ -1,0 +1,27 @@
+rules:
+  param-name-kebab-case:
+    description: "Parameter names should be in kebab-case."
+    severity: warning
+    given: "$.paths[*][*].parameters[*].name"
+    then:
+      function: pattern
+      functionOptions:
+        match: "^[a-z]+(-[a-z]+)*$"
+
+  path-name-kebab-case:
+    description: "Path segments should be in kebab-case."
+    severity: warning
+    given: "$.paths"
+    then:
+      function: pattern
+      functionOptions:
+        match: "^(/([a-z]+(-[a-z]+)*|{[^}]+}))*$"
+
+  response-description-sentence-case:
+    description: "Response descriptions should start with a capital letter."
+    severity: info
+    given: "$.paths[*][*].responses[*].description"
+    then:
+      function: pattern
+      functionOptions:
+        match: "^[A-Z].*"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+    "name": "api-governance",
+    "version": "1.0.0",
+    "description": "OWASP API Governance project to enforce best practices and validate OpenAPI specifications using Spectral.",
+    "main": "index.js",
+    "scripts": {
+      "lint:api": "npx spectral lint -r compiled-ruleset.json specs/**/*.yaml",
+      "lint:compile": "npx spectral compile .spectral.yaml -o compiled-ruleset.json",
+      "lint:validate": "npm run lint:compile && npm run lint:api",
+      "lint:single": "npx spectral lint -r compiled-ruleset.json specs/example-api.yaml"
+    },
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/Naman8kumar/www-project-api-governance.git"
+    },
+    "keywords": [
+      "spectral",
+      "api-governance",
+      "openapi",
+      "oas",
+      "linting",
+      "owasp"
+    ],
+    "author": "Naman Kumar",
+    "license": "MIT",
+    "devDependencies": {
+      "@stoplight/spectral-cli": "^6.1.0"
+    }
+  }
+  

--- a/specs/bookstore.yaml
+++ b/specs/bookstore.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.0
+info:
+  title: Book Store API
+  version: 1.0.0
+  contact:
+    email: contact@bookstore.com
+paths:
+  /books:
+    get:
+      summary: Get list of books
+      operationId: getBooks
+      tags:
+        - books
+      responses:
+        '200':
+          description: List of books
+components:
+  schemas:
+    Book:
+      type: object
+      properties:
+        title:
+          type: string
+        author:
+          type: string
+        isbn:
+          type: string

--- a/specs/petstore.yaml
+++ b/specs/petstore.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.0
+info:
+  title: Sample Pet Store API
+  version: 1.0.0
+  contact:
+    email: support@petstore.example.com
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      responses:
+        '200':
+          description: A list of pets.
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string

--- a/specs/sample-api.yaml
+++ b/specs/sample-api.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.0
+info:
+  title: Dummy API Spec
+  description: This is a sample API specification for testing Spectral linting GitHub Action.
+  version: 1.0.0
+paths:
+  /hello:
+    get:
+      summary: Say hello
+      responses:
+        '200':
+          description: A successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string

--- a/specs/weather-api.yaml
+++ b/specs/weather-api.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.0
+info:
+  title: Weather Info API
+  version: 1.0.0
+  contact:
+    name: Weather Support
+    email: help@weatherapi.example.com
+paths:
+  /weather:
+    get:
+      summary: Get current weather
+      operationId: getWeather
+      tags:
+        - weather
+      parameters:
+        - name: city
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Weather details
+components:
+  schemas:
+    WeatherResponse:
+      type: object
+      properties:
+        temperature:
+          type: string
+        condition:
+          type: string


### PR DESCRIPTION
This PR adds a new governance rule to ensure that every API response includes a description field for improved clarity and documentation quality.

🔧 Changes Made:
Added a Spectral rule to enforce mandatory response descriptions.

Updated .spectral.yaml configuration file.

Documented the new rule in docs/governance-rules.md.

Added sample API specs demonstrating valid and invalid cases (if applicable).

📌 Why this is important:
API responses without descriptions can confuse users and developers. This rule enforces better clarity and consistency across all specs.

